### PR TITLE
ModelSerializer's instance is not a list

### DIFF
--- a/rest_framework-stubs/serializers.pyi
+++ b/rest_framework-stubs/serializers.pyi
@@ -192,7 +192,6 @@ class ModelSerializer(Serializer[_MT]):
     serializer_url_field: type[RelatedField]
     serializer_choice_field: type[Field]
     url_field_name: str | None
-    instance: _MT | Sequence[_MT] | None  # type: ignore[assignment]
 
     class Meta:
         model: type[_MT]  # type: ignore


### PR DESCRIPTION
upstream PR: https://github.com/typeddjango/djangorestframework-stubs/pull/719